### PR TITLE
implement object store compatible tantivy directory

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,13 @@
+[target.'cfg(all())']
+rustflags = [
+    "-Wclippy::all",
+    # "-Wclippy::style",
+    "-Wclippy::fallible_impl_from",
+    "-Wclippy::manual_let_else",
+    "-Wclippy::redundant_pub_crate",
+    "-Wclippy::string_add_assign",
+    "-Wclippy::string_add",
+    "-Wclippy::string_lit_as_bytes",
+    "-Wclippy::string_to_string",
+    "-Wclippy::use_self",
+]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,52 @@
+name: Build and run Rust tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - "**/*"
+
+env:
+  # This env var is used by Swatinem/rust-cache@v2 for the cache
+  # key, so we set it to make sure it is always consistent.
+  CARGO_TERM_COLOR: always
+  # Disable full debug symbol generation to speed up CI build and keep memory down
+  # "1" means line tables only, which is useful for panic tracebacks.
+  RUSTFLAGS: "-C debuginfo=1"
+  RUST_BACKTRACE: "1"
+  # according to: https://matklad.github.io/2021/09/04/fast-rust-builds.html
+  # CI builds are faster with incremental disabled.
+  CARGO_INCREMENTAL: "0"
+  CARGO_BUILD_JOBS: "1"
+
+jobs:
+  linux-build:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libssl-dev
+      - name: Run cargo fmt
+        run: cargo fmt --check
+      - name: Clippy
+        run: |
+          cargo clippy --all-features --tests -- -D warnings
+      - name: Build
+        run: |
+          cargo build --all-features
+      - name: Build test
+        run: |
+          cargo test --all-features --no-run
+      - name: Run tests
+        run: |
+          cargo test --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "tantivy-object-store"
+version = "0.1.0"
+edition = "2021"
+authors = ["Lance Devs <dev@eto.ai>"]
+description = "A tantivy Directory implementation against object stores (S3, GCS, etc.)"
+license = "Apache-2.0"
+repository = "https://github.com/lancedb/tantivy-object-store"
+readme = "README.md"
+rust-version = "1.65"
+keywords = [
+    "full-text-search",
+    "search",
+    "search-engine",
+]
+categories = [
+    "data-structures",
+    "text-processing",
+    "filesystem",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+# 0.19 is when file handle started to return Arc instead of Box
+# https://github.com/quickwit-oss/tantivy/commit/775e936f7d8e461b7267bb13763db37c1c45afb8
+tantivy = ">=0.19"
+object_store = ">=0.6.1"
+async-trait = "0"
+tokio = { version = "1", features = ["full"] }
+uuid = "1"
+bytes = "1"
+log = "0"
+tempfile = "3"
+
+[dev-dependencies]
+env_logger = "0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-Nothing
+# Tantivy Object Store
+This repo contains an implementation of a `tantivy::directory::Directory` using an `object_store::ObjectStore`.
+
+This implementation supports both read and write, but does not implement locking or file watch. The index building process is responsible for making sure that no two concurrent builder runs at the same time
+
+A few notable behavior differences from tantivy's directory implementations:
+
+## Versioning
+Tantivy uses a file called `meta.json` which is a list of all the files that make up the index, effectively keeping track of a snapshot of the index. However, vanilla tantivy doesn't support versioning, meaning every time we update the index, meta.json is overwritten. This PR allows the caller to set a read_version and write_version. These version numbers are appended to the end of the file name when caller attempts to atomic_read or atomic_write.
+
+### Copy on Write (CoW)
+When creating a `ObjectStoreDirectory`, user may set `read_version` and `write_version`. `read_version` is used when user calls `atomic_read`. Instead of reading `meta.json`, we will try to read `meta.json.{read_version}`. Same when user calls `atomic_write`, we will try to write `meta.json.{write_version}`
+
+NOTE: The `write_version` take precedence over `read_version`. This means, after first write, `atomic_read` will read from `meta.json.{write_version}` NOT `meta.json.{read_version}`. This is needed because tantivy modifies `meta.json` file quite a few times during indexing, the CoW impl here needs have read-after-write consistency.
+
+## Index Reloading
+This implementation does not support reloading. If a `watch` callback is registered, the callback will never be called. User needs to handle reloading via other mechanisms for now.
+
+It maybe possible to use something like object store's native change notification to trigger reload, but that's for future work. 
+
+## Deletion
+Since tantivy attempts to garbage collect and merge index files during indexing, we had to change `delete` operation to noop. This is because we don't want tantivy to garbage collect files from past versions, as those files maybe in use by other readers. We will implement a garbage collection processes separately.
+
+## Threading
+This implementation contains a `tokio::Runtime` for running the IO jobs. This means, when calling functions from this implementation from inside another tokio runtime the caller should always use `tokio::task::spawn_blocking` so the task can be scheduled on a thread without tokio runtime. (This is needed because nesting tokio runtimes causes panic)
+
+## Concurrency Safety
+This implementation is concurrency safe within a single instance, as the `atomic_read|write` mechanism is a lock object in the returned trait object.
+
+## Performance
+TBD

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,629 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Object store (S3, AWS, etc.) support for tantivy.
+
+use async_trait::async_trait;
+use log::debug;
+use object_store::{local::LocalFileSystem, ObjectStore};
+use std::{
+    fs::File,
+    io::Write,
+    ops::Range,
+    path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+use tantivy::{
+    directory::{
+        self,
+        error::{DeleteError, LockError, OpenReadError, OpenWriteError},
+        AntiCallToken, Directory, DirectoryLock, FileHandle, OwnedBytes, TerminatingWrite,
+        WatchCallback, WatchHandle, WritePtr,
+    },
+    HasLen,
+};
+
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    sync::Mutex,
+};
+
+#[derive(Debug, Clone)]
+struct ObjectStoreDirectory {
+    store: Arc<dyn ObjectStore>,
+    base_path: String,
+    read_version: Option<u64>,
+    write_version: u64,
+
+    cache_loc: Arc<PathBuf>,
+
+    local_fs: Arc<LocalFileSystem>,
+
+    rt: Arc<tokio::runtime::Runtime>,
+    atomic_rw_lock: Arc<Mutex<()>>,
+}
+
+#[derive(Debug)]
+struct ObjectStoreFileHandle {
+    store: Arc<dyn ObjectStore>,
+    path: object_store::path::Path,
+    // We need to store this becasue the HasLen trait doesn't return a Result
+    // We need to do the IO at construction time
+    len: usize,
+
+    rt: Arc<tokio::runtime::Runtime>,
+}
+
+impl ObjectStoreFileHandle {
+    pub fn new(
+        store: Arc<dyn ObjectStore>,
+        path: object_store::path::Path,
+        len: usize,
+        rt: Arc<tokio::runtime::Runtime>,
+    ) -> Self {
+        Self {
+            store,
+            path,
+            len,
+            rt,
+        }
+    }
+}
+
+impl HasLen for ObjectStoreFileHandle {
+    fn len(&self) -> usize {
+        self.len
+    }
+}
+
+#[async_trait]
+impl FileHandle for ObjectStoreFileHandle {
+    fn read_bytes(&self, range: Range<usize>) -> std::io::Result<OwnedBytes> {
+        let handle = self.rt.handle();
+        handle.block_on(async { self.read_bytes_async(range).await })
+    }
+
+    #[doc(hidden)]
+    async fn read_bytes_async(&self, byte_range: Range<usize>) -> std::io::Result<OwnedBytes> {
+        debug!("read_bytes_async: {:?} {:?}", self.path, byte_range);
+        let bytes = self.store.get_range(&self.path, byte_range).await?;
+
+        Ok(OwnedBytes::new(bytes.to_vec()))
+    }
+}
+
+// super dumb implementation of a write handle
+// write to local and upload at once
+struct ObjectStoreWriteHandle {
+    store: Arc<dyn ObjectStore>,
+    location: object_store::path::Path,
+    local_path: Arc<PathBuf>,
+
+    write_handle: File,
+    shutdown: AtomicBool,
+    rt: Arc<tokio::runtime::Runtime>,
+}
+
+impl ObjectStoreWriteHandle {
+    pub fn new(
+        store: Arc<dyn ObjectStore>,
+        location: object_store::path::Path,
+        cache_loc: Arc<PathBuf>,
+        rt: Arc<tokio::runtime::Runtime>,
+    ) -> Result<Self, std::io::Error> {
+        let local_path = cache_loc.join(location.as_ref());
+        debug!("creating write handle for {:?}", local_path);
+        let path = Path::new(&local_path);
+        // create the necessary dir path for caching
+        std::fs::create_dir_all(path.parent().ok_or(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "unable to create parent dir for cache",
+        ))?)?;
+        let f = File::create(local_path.clone())?;
+
+        Ok(Self {
+            store,
+            location,
+            local_path: Arc::new(local_path),
+            write_handle: f,
+            shutdown: AtomicBool::new(false),
+            rt,
+        })
+    }
+}
+
+impl Write for ObjectStoreWriteHandle {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if self.shutdown.load(Ordering::SeqCst) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "write handle has been shutdown",
+            ));
+        }
+
+        self.write_handle.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        if self.shutdown.load(Ordering::SeqCst) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "write handle has been shutdown",
+            ));
+        }
+
+        self.write_handle.flush()
+    }
+}
+
+impl TerminatingWrite for ObjectStoreWriteHandle {
+    fn terminate_ref(&mut self, _: AntiCallToken) -> std::io::Result<()> {
+        let res = self.flush();
+        self.shutdown.store(true, Ordering::SeqCst);
+
+        let result: Result<(), std::io::Error> = self.rt.block_on(async {
+            let mut f = tokio::fs::File::open(self.local_path.as_path()).await?;
+
+            let (_, mut sink) = self.store.put_multipart(&self.location).await?;
+            // 1 mb blocks
+            let mut buf = vec![0; 1024 * 1024];
+
+            loop {
+                let n = f.read(&mut buf).await?;
+                if n == 0 {
+                    break;
+                }
+                sink.write_all(&buf[..n]).await?;
+            }
+
+            sink.shutdown().await?;
+
+            Ok(())
+        });
+
+        result?;
+
+        res
+    }
+}
+
+impl ObjectStoreDirectory {
+    fn to_object_path(&self, path: &Path) -> Result<object_store::path::Path, std::io::Error> {
+        let p = path
+            .to_str()
+            .ok_or(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "non-utf8 path",
+            ))?
+            .to_string();
+
+        Ok(object_store::path::Path::from(format!(
+            "{}/{}",
+            self.base_path.clone(),
+            p
+        )))
+    }
+
+    fn head(&self, path: &Path) -> Result<object_store::ObjectMeta, OpenReadError> {
+        let location = self
+            .to_object_path(path)
+            .map_err(|e| OpenReadError::wrap_io_error(e, path.to_path_buf()))?;
+        let handle = self.rt.handle();
+        handle
+            .block_on(async { self.store.head(&location).await })
+            .map_err(|e| match e {
+                object_store::Error::NotFound { .. } => {
+                    OpenReadError::FileDoesNotExist(path.to_path_buf())
+                }
+                _ => OpenReadError::wrap_io_error(
+                    std::io::Error::new(std::io::ErrorKind::Other, format!("{:?}", e)),
+                    path.to_path_buf(),
+                ),
+            })
+    }
+}
+
+trait Lock: Send + Sync + 'static {}
+struct NoOpLock {}
+impl NoOpLock {
+    pub fn new() -> Box<Self> {
+        Box::new(Self {})
+    }
+}
+impl Lock for NoOpLock {}
+
+impl Directory for ObjectStoreDirectory {
+    fn get_file_handle(&self, path: &Path) -> Result<Arc<dyn FileHandle>, OpenReadError> {
+        debug!("get_file_handle({:?})", path);
+        let location = self
+            .to_object_path(path)
+            .map_err(|e| OpenReadError::wrap_io_error(e, path.to_path_buf()))?;
+
+        // Check if the file is in local upload cache
+        let cache_path = self.cache_loc.join(location.as_ref());
+        let cache_path = object_store::path::Path::from(cache_path.to_string_lossy().as_ref());
+        if let Ok(meta) = self
+            .rt
+            .block_on(async { self.local_fs.head(&cache_path).await })
+        {
+            debug!("upload cache hit: {:?}", path);
+            return Ok(Arc::new(ObjectStoreFileHandle::new(
+                self.local_fs.clone(),
+                cache_path,
+                meta.size,
+                self.rt.clone(),
+            )));
+        }
+
+        let len = self.head(path)?.size;
+
+        Ok(Arc::new(ObjectStoreFileHandle::new(
+            self.store.clone(),
+            location,
+            len,
+            self.rt.clone(),
+        )))
+    }
+
+    fn atomic_read(&self, path: &Path) -> Result<Vec<u8>, OpenReadError> {
+        debug!("atomic_read({:?})", path);
+        if path != Path::new("meta.json") && path != Path::new(".managed.json") {
+            // Just blow up
+            unimplemented!("Only meta.json is supported, but got {:?}", path)
+        }
+
+        // Inject versioning into path -- we want to enforce CoW here
+        // if the write verison exist, read version has no effect
+        // if the write version doesn't exist we read from the old version
+
+        let buf = path.to_string_lossy();
+        let path_str = format!("{}.{}", buf, self.write_version);
+
+        // Found write version already valid, read from the write version
+        if let Ok(f) = self.get_file_handle(Path::new(&path_str)) {
+            return Ok(f
+                .read_bytes(0..f.len())
+                .map_err(|e| OpenReadError::wrap_io_error(e, path.to_path_buf()))?
+                .to_vec());
+        }
+
+        // No read version to copy from, return DNE
+        if self.read_version.is_none() {
+            return Err(OpenReadError::FileDoesNotExist(path.to_path_buf()));
+        }
+
+        let buf = path.to_string_lossy();
+        let path_str = format!(
+            "{}.{}",
+            buf,
+            self.read_version.expect("already checked exists")
+        );
+        let path = Path::new(&path_str);
+
+        let f = self.get_file_handle(path)?;
+        Ok(f.read_bytes(0..f.len())
+            .map_err(|e| OpenReadError::wrap_io_error(e, path.to_path_buf()))?
+            .to_vec())
+    }
+
+    fn exists(&self, path: &std::path::Path) -> Result<bool, OpenReadError> {
+        match self.head(path) {
+            Ok(_) => Ok(true),
+            Err(OpenReadError::FileDoesNotExist(_)) => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
+    // NOTE: the only thing that needs atomic write is the meta.json file
+    // we add versioning here in this interface to load different versions
+    // of the meta.json file at Directory construction time
+
+    fn atomic_write(&self, path: &Path, data: &[u8]) -> std::io::Result<()> {
+        debug!("atomic_write({:?})", path);
+        if path != Path::new("meta.json") && path != Path::new(".managed.json") {
+            // Just blow up
+            unimplemented!("Only meta.json is supported")
+        }
+
+        // Inject versioning into path
+        let buf = path.to_string_lossy();
+        let path_str = format!("{}.{}", buf, self.write_version);
+        let path = Path::new(&path_str);
+
+        let location = self.to_object_path(path)?;
+
+        debug!("true location: {:?}", location);
+
+        self.rt.handle().block_on(async {
+            // Lock so no one can write at the same time
+            let _ = self.atomic_rw_lock.lock().await;
+            self.store
+                .put(&location, bytes::Bytes::from(data.to_vec()))
+                .await
+        })?;
+
+        Ok(())
+    }
+
+    fn delete(&self, _: &Path) -> Result<(), DeleteError> {
+        // Don't actually garbage collect since we want to have versioning of the meta.json file
+        Ok(())
+    }
+
+    fn open_write(&self, path: &Path) -> Result<WritePtr, OpenWriteError> {
+        debug!("open_write({:?})", path);
+        let location = self
+            .to_object_path(path)
+            .map_err(|e| OpenWriteError::wrap_io_error(e, path.to_path_buf()))?;
+
+        debug!("true location: {:?}", location);
+
+        let write_handle = Box::new(
+            ObjectStoreWriteHandle::new(
+                self.store.clone(),
+                location,
+                self.cache_loc.clone(),
+                self.rt.clone(),
+            )
+            .map_err(|e| OpenWriteError::wrap_io_error(e, path.to_path_buf()))?,
+        );
+
+        Ok(WritePtr::new(write_handle))
+    }
+
+    fn sync_directory(&self) -> std::io::Result<()> {
+        // Noop as synchronization is handled by the object store
+        Ok(())
+    }
+
+    fn watch(&self, _: WatchCallback) -> tantivy::Result<WatchHandle> {
+        // We have reload mechanism from else where in the system
+        // A sinlge index load will always be immutable
+        Ok(WatchHandle::empty())
+    }
+
+    fn acquire_lock(&self, _: &directory::Lock) -> Result<DirectoryLock, LockError> {
+        // We will manually garueentee index RW safety
+        Ok(DirectoryLock::from(NoOpLock::new()))
+    }
+}
+
+/// Create a new object store directory that implements CoW for the meta.json file
+///
+/// # Arguments
+///
+/// * store - An object store object
+///
+/// * base_path - The base path to store the index, relative to the object store root
+///
+/// * read_version - The version of the meta.json file to read from if a write version hasn't been created.
+/// Can not be greater than the write version. Has no effect if there is a write version. Index will be
+/// built from scratch if None is provided.
+///
+/// * write_version - The version of the meta.json file to write to
+///
+/// * cache_loc - The location to cache the meta.json file. If not provided, a random UUID will be used.
+/// This string is used for caching uploaded artifacts under /tmp/{cache_loc} directory
+///
+/// * rt - An optional tokio runtime to use for async operations. If not provided, a new runtime will be created.
+/// NOTE: if you already run from an async context, dropping the returned Directory will cause the runtime to panic
+/// as it will attempt to shutdown the runtime inside an async context.
+///
+/// # Example
+/// ```
+/// use std::sync::Arc;
+///
+/// use object_store::local::LocalFileSystem;
+/// use tantivy::{Index, IndexSettings, schema::{Schema, STORED, STRING, TEXT}};
+/// use tantivy_object_store::new_object_store_directory;
+///
+/// let store = Arc::new(LocalFileSystem::new());
+/// let base_path = format!("/tmp/{}", uuid::Uuid::new_v4());
+/// let dir = new_object_store_directory(store, &base_path, Some(0), 1, None, None).unwrap();
+///
+/// let mut schema_builder = Schema::builder();
+/// let id_field = schema_builder.add_text_field("id", STRING);
+/// let text_field = schema_builder.add_text_field("text", TEXT | STORED);
+/// let schema = schema_builder.build();
+///
+/// let idx = tantivy::Index::create(dir, schema.clone(), IndexSettings::default()).unwrap();
+///
+///
+pub fn new_object_store_directory(
+    store: Arc<dyn ObjectStore>,
+    base_path: &str,
+    read_version: Option<u64>,
+    write_version: u64,
+    cache_loc: Option<&str>,
+    rt: Option<tokio::runtime::Runtime>,
+) -> Result<Box<dyn Directory>, std::io::Error> {
+    if let Some(read_version) = read_version {
+        if read_version > write_version {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "read version cannot be greater than write version",
+            ));
+        }
+    }
+
+    let cache_loc = cache_loc
+        .map(|s| Arc::new(Path::new(&s).to_owned()))
+        .unwrap_or(Arc::new(tempfile::tempdir()?.path().to_owned()));
+
+    Ok(Box::new(ObjectStoreDirectory {
+        store,
+        base_path: base_path.to_string(),
+        read_version,
+        write_version,
+        local_fs: Arc::new(LocalFileSystem::new()),
+        cache_loc,
+        rt: Arc::new(
+            rt.unwrap_or(
+                tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()?,
+            ),
+        ),
+        atomic_rw_lock: Arc::new(Mutex::new(())),
+    }))
+}
+
+#[cfg(test)]
+mod test {
+    use log::info;
+    use object_store::local::LocalFileSystem;
+    use std::sync::Arc;
+    use tantivy::{
+        doc,
+        schema::{Schema, STORED, STRING, TEXT},
+        IndexSettings,
+    };
+
+    use crate::new_object_store_directory;
+
+    #[test]
+    fn test_full_workflow() {
+        env_logger::init();
+
+        let store = Arc::new(LocalFileSystem::new());
+
+        let base_path = format!("/tmp/{}", uuid::Uuid::new_v4().hyphenated());
+
+        let dir =
+            new_object_store_directory(store.clone(), &base_path, None, 0, None, None).unwrap();
+
+        let mut schema_builder = Schema::builder();
+        let id_field = schema_builder.add_text_field("id", STRING);
+        let text_field = schema_builder.add_text_field("text", TEXT | STORED);
+        let schema = schema_builder.build();
+
+        info!("Creating index");
+        let idx = tantivy::Index::create(dir, schema.clone(), IndexSettings::default()).unwrap();
+
+        info!("Creating writer");
+        let mut writer = idx.writer(1024 * 1024 * 64).unwrap();
+        info!("Write doc 1");
+        writer
+            .add_document(doc!(
+                id_field => "1",
+                text_field => "hello world"
+            ))
+            .unwrap();
+        info!("Write doc 2");
+        writer
+            .add_document(doc!(
+                id_field => "2",
+                text_field => "Deus Ex"
+            ))
+            .unwrap();
+        info!("COMMIT!");
+        writer.commit().unwrap();
+
+        std::mem::drop(writer);
+        std::mem::drop(idx);
+
+        // try open again and add some data
+        let dir =
+            new_object_store_directory(store.clone(), &base_path, Some(0), 1, None, None).unwrap();
+
+        info!("Open index");
+        let idx = tantivy::Index::open(dir).unwrap();
+
+        info!("Creating writer");
+        let mut writer = idx.writer(1024 * 1024 * 64).unwrap();
+        info!("Write doc 3");
+        writer
+            .add_document(doc!(
+                id_field => "3",
+                text_field => "bye bye"
+            ))
+            .unwrap();
+        info!("COMMIT!");
+        writer.commit().unwrap();
+        info!("wait for merging threads");
+        writer.wait_merging_threads().unwrap();
+
+        std::mem::drop(idx);
+
+        // open and search
+        let dir =
+            new_object_store_directory(store.clone(), &base_path, None, 0, None, None).unwrap();
+
+        info!("Open index");
+        let s3_idx = tantivy::Index::open(dir).unwrap();
+        let query_parser =
+            tantivy::query::QueryParser::for_index(&s3_idx, vec![id_field, text_field]);
+        let searcher = s3_idx.reader().unwrap().searcher();
+
+        info!("searching 1");
+        let query = query_parser.parse_query("hello").unwrap();
+        let top_docs = searcher
+            .search(&query, &tantivy::collector::TopDocs::with_limit(10))
+            .unwrap();
+        assert_eq!(top_docs.len(), 1);
+        let doc = top_docs.get(0).unwrap().1;
+        let retrieved_doc = searcher.doc(doc).unwrap();
+        // we only store the text field, so there won't be an id field
+        assert_eq!(
+            retrieved_doc,
+            doc!(
+                text_field => "hello world"
+            )
+        );
+
+        info!("searching 2");
+        // No result -- not in this version
+        let query = query_parser.parse_query("bye").unwrap();
+        let top_docs = searcher
+            .search(&query, &tantivy::collector::TopDocs::with_limit(10))
+            .unwrap();
+        assert_eq!(top_docs.len(), 0);
+
+        info!("searching 3");
+        // finds the other doc
+        let query = query_parser.parse_query("ex").unwrap();
+        let top_docs = searcher
+            .search(&query, &tantivy::collector::TopDocs::with_limit(10))
+            .unwrap();
+
+        assert_eq!(top_docs.len(), 1);
+        let doc = top_docs.get(0).unwrap().1;
+        let retrieved_doc = searcher.doc(doc).unwrap();
+        // we only store the text field, so there won't be an id field
+        assert_eq!(
+            retrieved_doc,
+            doc!(
+                text_field => "Deus Ex"
+            )
+        );
+
+        // open a differnet version and search
+        let dir =
+            new_object_store_directory(store.clone(), &base_path, None, 1, None, None).unwrap();
+        info!("Open Index");
+        let s3_idx = tantivy::Index::open(dir).unwrap();
+        let searcher = s3_idx.reader().unwrap().searcher();
+
+        info!("searching 4");
+        // is in the newer version
+        let query = query_parser.parse_query("bye").unwrap();
+        let top_docs = searcher
+            .search(&query, &tantivy::collector::TopDocs::with_limit(10))
+            .unwrap();
+        assert_eq!(top_docs.len(), 1);
+    }
+}


### PR DESCRIPTION
This PR implements a tantivy::directory::Directory using an object_store::ObjectStore.

This implementation supports both read and write, but does not implement locking or file watch. The index building process is responsible for making sure that no two concurrent builder runs at the same time

A few notable behavior differences from tantivy's directory implementations:

## Versioning
tantivy uses a file called `meta.json` which is a list of all the files that make up the index to keep effectively keep track of a snapshot of the index. However, vanilla tantivy doesn't support versioning, meaning every time we update the index, meta.json is overwritten. This PR allows the caller to set a read_version and write_version. These version numbers are appended to the end of the file name when caller attempts to atomic_read or atomic_write.

### Copy on Write (CoW)
When creating a `ObjectStoreDirectory`, user may set `read_version` and `write_version`. `read_version` is used when user calls `atomic_read`. Instead of reading `meta.json` we try to read `meta.json.{read_version}` instead. Same when user calls `atomic_write`, we try to write `meta.json.{write_version}`

NOTE: in the `write_version` take precedence over `read_version`. This means, after first write, `atomic_read` will read from `meta.json.{write_version}` NOT `meta.json.{read_version}`. This is needed because tantivy modifies `meta.json` file quite a few times during indexing, the CoW impl here needs have read-after-write consistency.

## Index Reloading
This implementation does not support reloading. If a `watch` callback is registered, the callback will never be called. User needs to handle reloading via other mechanisms for now.

It maybe possible to use something like object store's native change notification to trigger reload, but that's for future work. 

## Deletion
Since tantivy attempts to garbage collect and merge index files during indexing, we had to change `delete` operation to noop. This is because we don't want tantivy to garbage collect files from past versions. We will implement a garbage collection processes separately.

## Threading
This implementation contains a `tokio::Runtime` for running the IO jobs. This means, when calling functions from this implementation from inside another tokio runtime should always use `tokio::task::spawn_blocking` so the task can be scheduled on a thread without tokio runtime. (This is needed because nesting tokio runtimes causes panic)